### PR TITLE
Refactored to use the new imageUrl from core

### DIFF
--- a/src/components/flag.component.html
+++ b/src/components/flag.component.html
@@ -9,5 +9,5 @@
     gradient
   ]"
 >
-  <img [src]="'https://raw.githubusercontent.com/Yummygum/flag-pack-core/master/svg/' + size.toLowerCase() + '/' + assetCode + '.svg?sanitize=true'">
+  <img [src]="src">
 </div>

--- a/src/components/flag.component.ts
+++ b/src/components/flag.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 
 // This fixes the build that breaks.
 declare var require: any
-const { isoToCountryCode } =  require('flagpack-core');
+const { isoToCountryCode, imageUrl } =  require('flagpack-core');
 
 @Component({
   selector: 'flag',
@@ -23,5 +23,7 @@ export class FlagComponent {
     return isoToCountryCode(this.code.toUpperCase());
   }
 
-  constructor() {}
+  get src(): String {
+    return imageUrl(this.assetCode, this.size.toLowerCase());
+  }
 }


### PR DESCRIPTION
Following [my changes on flag-pack-core](https://github.com/Yummygum/flag-pack-core/pull/5), the code now uses the new `imageUrl()` function  to get the image URL instead of a hardcoded GitHub request.